### PR TITLE
cache should be based on source, not on target

### DIFF
--- a/ci/prepare-host
+++ b/ci/prepare-host
@@ -8,16 +8,18 @@ _cache() {
   shift 1
   local FETCHCMD="$@"
 
+  local KEY=$(md5sum <<<"$FETCHCMD" | cut -d " " -f1)
+
   [[ ! -d cache ]] && mkdir cache
 
-  if [[ ! -e "cache/$BIN" ]];
+  if [[ ! -e "cache/$KEY" ]];
   then
     # We expect the FETCHCMD to provide $BIN in $PWD
     eval "$FETCHCMD"
-    mv "$BIN" "cache/$BIN"
+    mv "$BIN" "cache/$KEY"
   fi
 
-  ln -fv "cache/$BIN" "$BIN"
+  ln -fv "cache/$KEY" "$BIN"
 }
 
 _virtctl() {


### PR DESCRIPTION
Previously we only cached based on the name, but this is an issue
as we use seeveral oc, kuberctl, etc versions, which all map to
the same name.
Thus now the cache is based on the source of the binary, which
includes the version.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>