### PR TITLE
Add oc cluster up localdirectory to .dockerignore

### DIFF
--- a/ci/prepare-host
+++ b/ci/prepare-host
@@ -80,6 +80,7 @@ _minikube() {
 _oc_cluster() {
   sudo sed -i 's%DOCKER_OPTS=\"%DOCKER_OPTS=\"--insecure-registry 172.30.0.0/16 %' /etc/default/docker
   sudo systemctl restart docker
+  echo 'openshift.local.clusterup' >> .dockerignore
 
   _oc
 }


### PR DESCRIPTION
Add oc cluster up localdirectory to .dockerignore to allow local dock…

docker build systematically fails for me due with:
```
  docker build -t docker.io/kubevirt/cdi-operator:latest -f Dockerfile .
  error checking context: 'can't stat '/home/travis/build/tiraboschi/cdi-operator/openshift.local.clusterup/etcd/member''.
  Makefile:42: recipe for target 'build' failed
```

The issue is caused by the permissions of openshift.local.clusterup.
Adding it to .dockerignore at host_prepare time to fix it.