### PR TITLE
rename of kubevirt namespace

### DIFF
--- a/ci/defaults
+++ b/ci/defaults
@@ -2,7 +2,7 @@ DEFAULT_PLATFORM=minikube
 DEFAULT_CLUSTER=kubernetes
 # Intentionally unset, as set my platform usually
 DEFAULT_CLUSTER_VERSION=
-DEFAULT_KUBEVIRT_VER=0.11.0
+DEFAULT_KUBEVIRT_VER=v0.12.0-alpha.3
 
 declare -A CDIST_ON
 CDIST_ON[minikube]=kubernetes

--- a/ci/deploy-kubevirt
+++ b/ci/deploy-kubevirt
@@ -8,8 +8,8 @@ source $(dirname $(realpath $0))/defaults
 _kubernetes() {
   local VER=$1
 
-  kubectl create configmap -n kube-system kubevirt-config --from-literal debug.useEmulation=true || :
-  kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/v$VER/kubevirt.yaml ;
+  kubectl create configmap -n kubevirt kubevirt-config --from-literal debug.useEmulation=true || :
+  kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/$VER/kubevirt.yaml ;
 }
 
 _origin() {
@@ -19,9 +19,9 @@ _origin() {
 
   _kubernetes $VER
 
-  oc adm policy add-scc-to-user privileged -n kube-system -z kubevirt-privileged
-  oc adm policy add-scc-to-user privileged -n kube-system -z kubevirt-controller
-  oc adm policy add-scc-to-user privileged -n kube-system -z kubevirt-apiserver
+  oc adm policy add-scc-to-user privileged -n kubevirt -z kubevirt-privileged
+  oc adm policy add-scc-to-user privileged -n kubevirt -z kubevirt-controller
+  oc adm policy add-scc-to-user privileged -n kubevirt -z kubevirt-apiserver
 }
 
 _${CDIST_ON[${1:-$DEFAULT_PLATFORM}]} ${2:-$DEFAULT_KUBEVIRT_VER}


### PR DESCRIPTION
Kubevirt 0.12.0 moved from kube-system to kubevirt namespace. This PR changes kubevirt namespace.
@fabiand  do you want to keep compatibility with older versions of kubevirt and check if user is using <0.12.0 version and then set correct namespace?