### PR TITLE
Bump version to 0.15.0

### DIFF
--- a/ci/defaults
+++ b/ci/defaults
@@ -2,7 +2,7 @@ DEFAULT_PLATFORM=minikube
 DEFAULT_CLUSTER=kubernetes
 # Intentionally unset, as set my platform usually
 DEFAULT_CLUSTER_VERSION=
-DEFAULT_KUBEVIRT_VER=v0.14.0
+DEFAULT_KUBEVIRT_VER=v0.15.0
 
 declare -A CDIST_ON
 CDIST_ON[minikube]=kubernetes

--- a/ci/deploy-kubevirt
+++ b/ci/deploy-kubevirt
@@ -29,7 +29,7 @@ _origin() {
     # Workaround for travis
     oc adm policy add-scc-to-group anyuid system:authenticated
   else
-    oc adm policy add-scc-to-user privileged -n kubevirt -z kubevirt-privileged
+    oc adm policy add-scc-to-user privileged -n kubevirt -z kubevirt-handler
     oc adm policy add-scc-to-user privileged -n kubevirt -z kubevirt-controller
     oc adm policy add-scc-to-user privileged -n kubevirt -z kubevirt-apiserver
   fi


### PR DESCRIPTION
0.14.0 fails to pass kubevirt/demo change that adjusts demo VM yaml file
to kubevirt.io/v1alpha3.