### PR TITLE
Fixed fetching virt-handler logs using openshift client

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,14 @@
-kubectl logs -l kubevirt.io=virt-handler --all-containers
+function get_handler_pods {
+  kubectl get pods -n kubevirt -l kubevirt.io=virt-handler | tail -n +2 | awk -e '{print$1}'
+}
+
+function get_handler_logs {
+  for pod in $(get_handler_pods); do
+    kubectl logs -n kubevirt $pod
+  done
+}
+
+get_handler_pods
 kubectl get events --all-namespaces
 kubectl get pods --all-namespaces
 kubectl describe nodes | tee /dev/stderr | grep devices.kubevirt.io/tun

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,5 @@
 function get_handler_pods {
-  kubectl get pods -n kubevirt -l kubevirt.io=virt-handler | tail -n +2 | awk -e '{print$1}'
+  kubectl get pods -n kubevirt -l kubevirt.io=virt-handler --no-headers
 }
 
 function get_handler_logs {

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@ function get_handler_logs {
   done
 }
 
-get_handler_pods
+get_handler_logs
 kubectl get events --all-namespaces
 kubectl get pods --all-namespaces
 kubectl describe nodes | tee /dev/stderr | grep devices.kubevirt.io/tun


### PR DESCRIPTION
The client doesn't support -l with no pod name (upstream kubectl does).